### PR TITLE
feat: add a latest quote endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,11 +165,19 @@ all: test build ## Run all tests and build the site.
 
 .PHONY: build
 build: .venv/.installed mkdocs ## Build the site files.
-	@$(REPO_ROOT)/.venv/bin/python fx/main.py build
+	debugarg=""; \
+	if [ -n "$(DEBUG_LOGGING)" ]; then \
+		debugarg="--debug"; \
+	fi; \
+	$(REPO_ROOT)/.venv/bin/python3 fx/main.py $${debugarg} build
 
 .PHONY: update
 update: .venv/.installed ## Update API data.
-	@$(REPO_ROOT)/.venv/bin/python fx/main.py update --start "$$(date -d "-14 days" +"%Y-%m-%d")"
+	debugarg=""; \
+	if [ -n "$(DEBUG_LOGGING)" ]; then \
+		debugarg="--debug"; \
+	fi; \
+	$(REPO_ROOT)/.venv/bin/python3 fx/main.py $${debugarg} update --start "$$(date -d "-14 days" +"%Y-%m-%d")"
 
 .PHONY: mkdocs
 mkdocs: .venv/.installed ## Generate API documentation.
@@ -177,7 +185,7 @@ mkdocs: .venv/.installed ## Generate API documentation.
 
 .PHONY: serve
 serve: build ## Serve the API locally.
-	@$(REPO_ROOT)/.venv/bin/python -m http.server --directory _site/
+	@$(REPO_ROOT)/.venv/bin/python3 -m http.server --directory _site/
 
 .PHONY: protoc
 protoc: fx/currency_pb2.py fx/provider_pb2.py fx/quote_pb2.py ## Compile protobuf files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -167,6 +167,38 @@ Quotes for a single day can be accessed by date.
 }
 ```
 
+#### [`/v1/provider/MUFG/quote/USD/JPY/latest.json`](/v1/provider/MUFG/quote/USD/JPY/latest.json)
+
+The most recent quote for a currency pair can be accessed via the `latest` endpoint.
+
+```json
+{
+    "providerCode": "MUFG",
+    "date": {
+        "year": 2025,
+        "month": 9,
+        "day": 22
+    },
+    "baseCurrencyCode": "USD",
+    "quoteCurrencyCode": "JPY",
+    "ask": {
+        "currencyCode": "JPY",
+        "units": "149",
+        "nanos": 290000000
+    },
+    "bid": {
+        "currencyCode": "JPY",
+        "units": "147",
+        "nanos": 290000000
+    },
+    "mid": {
+        "currencyCode": "JPY",
+        "units": "148",
+        "nanos": 290000000
+    }
+}
+```
+
 ## Formats
 
 Each endpoint can be accessed in JSON (`.json`), CSV (`.csv`), and Protocol

--- a/docs/v1/openapi.yaml
+++ b/docs/v1/openapi.yaml
@@ -116,7 +116,7 @@ components:
 paths:
   /currency.json:
     get:
-      summary: Returns a list of currencies.
+      summary: Get supported currencies.
       description: Returns a full list of currencies. Not all providers support all currencies.
       responses:
         "200": # status code
@@ -128,8 +128,8 @@ paths:
 
   /currency/{currency_code}.json:
     get:
-      summary: Returns a currency.
-      description: Returns a currency corresponding to `code`.
+      summary: Get a currency by code.
+      description: Returns a currency corresponding to the currency code.
       parameters:
         - name: currency_code
           in: path
@@ -147,7 +147,7 @@ paths:
 
   /provider.json:
     get:
-      summary: Returns a list of providers.
+      summary: Get supported providers.
       description: Returns a full list of supported currency conversion providers.
       responses:
         "200": # status code
@@ -159,7 +159,7 @@ paths:
 
   /provider/{provider_code}.json:
     get:
-      summary: Returns a provider.
+      summary: Get a provider by code.
       description: Returns a supported currency conversion provider.
       parameters:
         - name: provider_code
@@ -176,9 +176,40 @@ paths:
               schema:
                 $ref: "#/components/schemas/Provider"
 
+  /provider/{provider_code}/quote/{base_currency_code}/{quote_currency_code}/latest.json:
+    get:
+      summary: Get the most recent daily quote.
+      description: Returns the most recent currency conversion quote for the given provider.
+      parameters:
+        - name: provider_code
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The provider code.
+        - name: base_currency_code
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ISO 4217 currency code for the base currency.
+        - name: quote_currency_code
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The ISO 4217 currency code for the quote currency.
+      responses:
+        "200": # status code
+          description: A Quote object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Quote"
+
   /provider/{provider_code}/quote/{base_currency_code}/{quote_currency_code}/{year}/{month}/{day}.json:
     get:
-      summary: Returns a daily quote.
+      summary: Get a quote by date.
       description: Returns a daily currency conversion quote for the given provider.
       parameters:
         - name: provider_code
@@ -230,7 +261,7 @@ paths:
 
   /provider/{provider_code}/quote/{base_currency_code}/{quote_currency_code}/{year}/{month}.json:
     get:
-      summary: Returns a list of quote for the month.
+      summary: Get quotes by month.
       description: Returns a list daily currency conversion quote for the provider in the given month.
       parameters:
         - name: provider_code
@@ -275,7 +306,7 @@ paths:
 
   /provider/{provider_code}/quote/{base_currency_code}/{quote_currency_code}/{year}.json:
     get:
-      summary: Returns a list of quote for the year.
+      summary: Get quotes by year.
       description: Returns a list daily currency conversion quote for the provider in the given year.
       parameters:
         - name: provider_code

--- a/fx/quote.py
+++ b/fx/quote.py
@@ -199,9 +199,17 @@ def write_month_quotes_site(base_dir, month, quotelist, logger):
 
 
 def write_day_quote_site(base_dir, quote, logger):
+    _write_quote_site(base_dir, f"{quote.date.day:02d}", quote, logger)
+
+
+def write_latest_quote_site(base_dir, quote, logger):
+    _write_quote_site(base_dir, "latest", quote, logger)
+
+
+def _write_quote_site(base_dir, file_name, quote, logger):
     os.makedirs(base_dir, exist_ok=True)
 
-    json_path = os.path.join(base_dir, f"{quote.date.day:02d}.json")
+    json_path = os.path.join(base_dir, f"{file_name}.json")
     logger.debug(f"writing {json_path}...")
 
     # write currencies list JSON.
@@ -209,11 +217,11 @@ def write_day_quote_site(base_dir, quote, logger):
         json.dump(MessageToDict(quote), f)
 
     # write quote list CSV.
-    csv_path = os.path.join(base_dir, f"{quote.date.day:02d}.csv")
+    csv_path = os.path.join(base_dir, f"{file_name}.csv")
     write_quotes_csv(csv_path, [quote], logger)
 
     # Write quote list proto
-    proto_path = os.path.join(base_dir, f"{quote.date.day:02d}.binpb")
+    proto_path = os.path.join(base_dir, f"{file_name}.binpb")
     with open(proto_path, "wb") as f:
         logger.debug(f"writing {f.name}...")
         f.write(quote.SerializeToString())


### PR DESCRIPTION
**Description:**

Adds an endpoint that returns the latest quote for a provider and currency pair. The quote can be retrieved from the path:

    /v1/provider/<provider_code>/quote/<base_currency>/<quote_currency>/latest.<format>

**Related Issues:**

Fixes #83 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
