### PR TITLE
chore: add `fx` as a package script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ _site/
 # Python caches and build directories.
 *.py[cod]
 *.egg-info/
+build/
 dist/
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -168,23 +168,33 @@ package: .venv/.installed ## Package the project for distribution.
 	@# bash \
 	$(REPO_ROOT)/.venv/bin/python3 -m build
 
+.PHONY: install
+install: .venv/.installed ## Install the package in the local venv.
+	@# bash \
+	$(REPO_ROOT)/.venv/bin/pip install .
+
 .PHONY: build
-build: .venv/.installed mkdocs ## Build the site files.
+build: install mkdocs ## Build the site files.
 	@# bash \
 	debugarg=""; \
 	if [ -n "$(DEBUG_LOGGING)" ]; then \
 		debugarg="--debug"; \
 	fi; \
-	$(REPO_ROOT)/.venv/bin/python3 fx/main.py $${debugarg} build
+	$(REPO_ROOT)/.venv/bin/fx \
+		$${debugarg} \
+		build
 
 .PHONY: update
-update: .venv/.installed ## Update API data.
+update: install ## Update API data.
 	@# bash \
 	debugarg=""; \
 	if [ -n "$(DEBUG_LOGGING)" ]; then \
 		debugarg="--debug"; \
 	fi; \
-	$(REPO_ROOT)/.venv/bin/python3 fx/main.py $${debugarg} update --start "$$(date -d "-14 days" +"%Y-%m-%d")"
+	$(REPO_ROOT)/.venv/bin/fx \
+		$${debugarg} \
+		update \
+		--start "$$(date -d "-14 days" +"%Y-%m-%d")"
 
 .PHONY: mkdocs
 mkdocs: .venv/.installed ## Generate API documentation.

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,14 @@ $(AQUA_ROOT_DIR)/.installed: .aqua.yaml .bin/aqua-$(AQUA_VERSION)/aqua
 .PHONY: all
 all: test build ## Run all tests and build the site.
 
+.PHONY: package
+package: .venv/.installed ## Package the project for distribution.
+	@# bash \
+	$(REPO_ROOT)/.venv/bin/python3 -m build
+
 .PHONY: build
 build: .venv/.installed mkdocs ## Build the site files.
+	@# bash \
 	debugarg=""; \
 	if [ -n "$(DEBUG_LOGGING)" ]; then \
 		debugarg="--debug"; \
@@ -173,6 +179,7 @@ build: .venv/.installed mkdocs ## Build the site files.
 
 .PHONY: update
 update: .venv/.installed ## Update API data.
+	@# bash \
 	debugarg=""; \
 	if [ -n "$(DEBUG_LOGGING)" ]; then \
 		debugarg="--debug"; \
@@ -181,17 +188,20 @@ update: .venv/.installed ## Update API data.
 
 .PHONY: mkdocs
 mkdocs: .venv/.installed ## Generate API documentation.
-	@$(REPO_ROOT)/.venv/bin/mkdocs build
+	@# bash \
+	$(REPO_ROOT)/.venv/bin/mkdocs build
 
 .PHONY: serve
 serve: build ## Serve the API locally.
-	@$(REPO_ROOT)/.venv/bin/python3 -m http.server --directory _site/
+	@# bash \
+	$(REPO_ROOT)/.venv/bin/python3 -m http.server --directory _site/
 
 .PHONY: protoc
 protoc: fx/currency_pb2.py fx/provider_pb2.py fx/quote_pb2.py ## Compile protobuf files.
 
 fx/%_pb2.py: .venv/.installed fx/%.proto
-	@protoc --proto_path=. --proto_path=.venv/lib/python3.10/site-packages/ --python_out=. $(word 2,$^)
+	@# bash \
+	protoc --proto_path=. --proto_path=.venv/lib/python3.10/site-packages/ --python_out=. $(word 2,$^)
 
 ## Testing
 #####################################################################
@@ -610,6 +620,7 @@ clean: ## Delete temporary files.
 	@$(RM) -r .venv/
 	@$(RM) -r node_modules/
 	@$(RM) *.sarif.json
+	@$(RM) -r build/
 	@$(RM) -r dist/
 	@$(RM) -r *.egg-info/
 	@$(RM) -r _site/

--- a/fx/build.py
+++ b/fx/build.py
@@ -19,9 +19,13 @@ import os.path
 import re
 import time
 
-from provider import write_providers_site
-from currency import read_currencies_data, write_currencies_site
-from quote import read_quotelist_data, write_latest_quote_site, write_year_quotes_site
+from fx.provider import write_providers_site
+from fx.currency import read_currencies_data, write_currencies_site
+from fx.quote import (
+    read_quotelist_data,
+    write_latest_quote_site,
+    write_year_quotes_site,
+)
 
 
 def update_latest_quotes(latest_quotes, provider_code, quotelist):

--- a/fx/currency.py
+++ b/fx/currency.py
@@ -25,8 +25,8 @@ from google.protobuf.json_format import MessageToDict
 from google.type.date_pb2 import Date
 import urllib3
 
-from currency_pb2 import Currency, CurrencyList
-from utils import date_msg_to_str
+from fx.currency_pb2 import Currency, CurrencyList
+from fx.utils import date_msg_to_str
 
 ISO_DOWNLOAD_XML = "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
 ISO_DOWNLOAD_HISTORIC_XML = "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml"

--- a/fx/main.py
+++ b/fx/main.py
@@ -16,9 +16,9 @@ import argparse
 import logging
 from datetime import date
 
-from build import build_command
-from update import update_command
-from mufg import MUFGProvider
+from fx.build import build_command
+from fx.update import update_command
+from fx.mufg import MUFGProvider
 
 
 def main():

--- a/fx/mufg.py
+++ b/fx/mufg.py
@@ -18,8 +18,8 @@ from bs4 import BeautifulSoup
 from google.type.date_pb2 import Date
 import urllib3
 
-from quote_pb2 import Quote
-from utils import str_to_money
+from fx.quote_pb2 import Quote
+from fx.utils import str_to_money
 
 
 class MUFGProvider:

--- a/fx/provider.py
+++ b/fx/provider.py
@@ -20,7 +20,7 @@ import json
 
 from google.protobuf.json_format import MessageToDict
 
-from provider_pb2 import ProviderList
+from fx.provider_pb2 import ProviderList
 
 
 def write_providers_site(base_dir, providers, logger):

--- a/fx/quote.py
+++ b/fx/quote.py
@@ -24,8 +24,8 @@ import os.path
 from dateutil.relativedelta import relativedelta
 from google.protobuf.json_format import MessageToDict
 
-from quote_pb2 import QuoteList
-from utils import dateIterator, date_msg_to_str, money_to_str
+from fx.quote_pb2 import QuoteList
+from fx.utils import dateIterator, date_msg_to_str, money_to_str
 
 
 def quote_in(q, quotes):

--- a/fx/update.py
+++ b/fx/update.py
@@ -20,9 +20,9 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta
 
-from currency import download_currencies, write_currencies_data
-from quote import download_quotes, write_quotes_data
-from utils import dateIterator
+from fx.currency import download_currencies, write_currencies_data
+from fx.quote import download_quotes, write_quotes_data
+from fx.utils import dateIterator
 
 
 def update_command(args):

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,8 @@
 base = "."
 publish = "_site/"  # relative to `base` directory
 command = "make build"
-environment = { PYTHON_VERSION = "3.10" }
+# NOTE: This should match the Python version in `.python-version`.
+environment = { PYTHON_VERSION = "3.13.5" }
 
 [[headers]]
   for = "/v1/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 
+[project.scripts]
+fx = "fx.main:main"
+
 [project.urls]
 Homepage = "https://fx.ianlewis.org/"
 Issues = "https://github.com/ianlewis/fx/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 description = "A simple currency exchange rate API"
 readme = "README.md"
 # NOTE: this should be compatible with the `.python-version` file.
-requires-python = "==3.13.5"
+requires-python = ">=3.13.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
**Description:**

Adds an `fx` command script to the Python package. When code is run, the package is installed in the local venv and `fx` is run from there.

**Related Issues:**

Fixes #87 
Fixes #10 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
