### PR TITLE
fix(ci): get origin default branch for commitlint

### DIFF
--- a/.github/workflows/workflow_call.commitlint.yml
+++ b/.github/workflows/workflow_call.commitlint.yml
@@ -44,6 +44,10 @@ jobs:
       # NOTE: actions/checkout does not set up local branches
       - run: |
           set -euo pipefail
+          # Fetch the HEAD ref. This is necessary to get the correct default branch.
+          git remote set-head origin --auto
+
+          # Create local branches for all remote branches except pull requests.
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           for remote_branch in $(git branch -r | grep -v "\->" | grep -v -e "^\s*pull/"); do
             local_branch=$(echo "${remote_branch}" | sed 's/origin\///')


### PR DESCRIPTION
**Description:**

Get the `origin` remote's `HEAD` ref so that it can be used to determine the default branch.

**Related Issues:**

Fixes #101 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
