### PR TITLE
feat: compact JSON output

### DIFF
--- a/fx/currency.py
+++ b/fx/currency.py
@@ -199,7 +199,7 @@ def write_currencies_site(
 
     # write currencies list JSON.
     with json_path.open("w") as f:
-        json.dump(MessageToDict(clist), f)
+        json.dump(MessageToDict(clist), f, separators=(",", ":"))
 
     # write currencies list CSV.
     csv_path = base_path.joinpath("currency.csv")
@@ -244,7 +244,7 @@ def write_currencies_site(
         c_json_path = currency_path.joinpath(f"{c.alphabetic_code}.json")
         with c_json_path.open("w") as f:
             logger.debug("writing %s...", f.name)
-            json.dump(MessageToDict(c), f)
+            json.dump(MessageToDict(c), f, separators=(",", ":"))
 
         # Write currency csv
         c_csv_path = currency_path.joinpath(f"{c.alphabetic_code}.csv")

--- a/fx/provider.py
+++ b/fx/provider.py
@@ -55,7 +55,7 @@ def write_providers_site(
 
     # Write providers list JSON.
     with json_path.open("w") as f:
-        json.dump(MessageToDict(plist), f)
+        json.dump(MessageToDict(plist), f, separators=(",", ":"))
 
     # Write providers list CSV.
     csv_path = base_path.joinpath("provider.csv")
@@ -93,7 +93,7 @@ def write_providers_site(
         p_json_path = provider_path.joinpath(f"{p.code}.json")
         with p_json_path.open("w") as f:
             logger.debug("writing %s...", f.name)
-            json.dump(MessageToDict(p), f)
+            json.dump(MessageToDict(p), f, separators=(",", ":"))
 
         # Write provider CSV
         p_csv_path = provider_path.joinpath(f"{p.code}.csv")

--- a/fx/quote.py
+++ b/fx/quote.py
@@ -204,7 +204,7 @@ def write_year_quotes_site(
 
     # Write currencies list JSON.
     with json_path.open("w") as f:
-        json.dump(MessageToDict(quotelist), f)
+        json.dump(MessageToDict(quotelist), f, separators=(",", ":"))
 
     # Write quote list CSV.
     csv_path = base_path.joinpath(f"{year:04d}.csv")
@@ -253,7 +253,7 @@ def write_month_quotes_site(
 
     # write currencies list JSON.
     with json_path.open("w") as f:
-        json.dump(MessageToDict(quotelist), f)
+        json.dump(MessageToDict(quotelist), f, separators=(",", ":"))
 
     # write quote list CSV.
     csv_path = base_path.joinpath(f"{month:02d}.csv")
@@ -302,7 +302,7 @@ def _write_quote_site(
 
     # write currencies list JSON.
     with json_path.open("w") as f:
-        json.dump(MessageToDict(quote), f)
+        json.dump(MessageToDict(quote), f, separators=(",", ":"))
 
     # write quote list CSV.
     csv_path = base_path.joinpath(f"{file_name}.csv")


### PR DESCRIPTION
**Description:**

Remove unnecessary whitespace from output to compact the JSON. Tests show this saves about 8% of the space in the JSON output.

**Related Issues:**

Fixes #116 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
