### PR TITLE
fix: pin the buf.build plugin version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ actionlint: $(AQUA_ROOT_DIR)/.installed ## Runs the actionlint linter.
 	fi
 
 .PHONY: buf
-buf: $(AQUA_ROOT_DIR)/.installed .venv/.installed node_modules/.installed ## Runs the buf linter.
+buf: $(AQUA_ROOT_DIR)/.installed .venv/.installed ## Runs the buf linter.
 	@# bash \
 	files=$$( \
 		git ls-files --deduplicate \

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -16,7 +16,10 @@ version: v2
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/python
+  # NOTE: Updating the version here seems to update the runtime version in the
+  #       generated code even though the installed version in the virtual
+  #       environment is different. Ensure these versions match when updating.
+  - remote: buf.build/protocolbuffers/python:v33.2
     out: .
 inputs:
   - directory: proto


### PR DESCRIPTION
**Description:**

Pin the buf.build python protocolbuffers version to ensure it generates the correct runtime version in code.

**Related Issues:**

Fixes #160 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
